### PR TITLE
Removed never reachable if statement

### DIFF
--- a/src/php-8.1-strftime.php
+++ b/src/php-8.1-strftime.php
@@ -30,10 +30,6 @@
 
     $timestamp = new DateTime($timestamp);
 
-    if (!($timestamp instanceof DateTimeInterface)) {
-      throw new InvalidArgumentException('$timestamp argument is neither a valid UNIX timestamp, a valid date-time string or a DateTime object.');
-    }
-
     $timestamp->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
     if (empty($locale)) {

--- a/src/php-8.1-strftime.php
+++ b/src/php-8.1-strftime.php
@@ -26,9 +26,11 @@
    * @author BohwaZ <https://bohwaz.net/>
    */
   function strftime (string $format, $timestamp = null, ?string $locale = null) : string {
-    $timestamp = is_int($timestamp) ? '@' . $timestamp : (string) $timestamp;
+    if (!($timestamp instanceof DateTimeInterface)) {
+      $timestamp = is_int($timestamp) ? '@' . $timestamp : (string) $timestamp;
 
-    $timestamp = new DateTime($timestamp);
+      $timestamp = new DateTime($timestamp);
+    }
 
     $timestamp->setTimezone(new DateTimeZone(date_default_timezone_get()));
 


### PR DESCRIPTION
The class type check will never return false, as DateTime is always an instance of DateTimeInterface. If the passed `$timestamp` is invalid, then the DateTime constructor will throw an `\Exception`, therefore the check is not needed.