### PR TITLE
Minus prefix should also remove leading space

### DIFF
--- a/src/php-8.1-strftime.php
+++ b/src/php-8.1-strftime.php
@@ -206,7 +206,7 @@
         case '#':
         case '-':
           // remove leading zeros but keep last char if also zero
-          return preg_replace('/^0+(?=.)/', '', $result);
+          return preg_replace('/^[0\s]+(?=.)/', '', $result);
       }
 
       return $result;

--- a/tests/strftimeTest.php
+++ b/tests/strftimeTest.php
@@ -48,6 +48,12 @@
       $result = strftime('%e', '20220306 13:02:03');
       $this->assertEquals(' 6', $result, '%e: Day of the month, with a space preceding single digits');
 
+      $result = strftime('%#e', '20220306 13:02:03');
+      $this->assertEquals('6', $result, '%#e: Day of the month, without leading space');
+
+      $result = strftime('%-e', '20220306 13:02:03');
+      $this->assertEquals('6', $result, '%-e: Day of the month, without leading space');
+
       $result = strftime('%j', '20220306 13:02:03');
       $this->assertEquals('065', $result, '%j: Day of the year, 3 digits with leading zeros');
 


### PR DESCRIPTION
Default PHP strftime() also remove leading space when using the minus prefix.

Expected result :
'%-e' => '3'

Actual result :
'%-e' => ' 3'