### PR TITLE
#15 Fix fatal error with non-Gregorian locales

### DIFF
--- a/src/php-8.1-strftime.php
+++ b/src/php-8.1-strftime.php
@@ -95,7 +95,9 @@
       //  in formatted strings.
       // To adjust for this, a custom calendar can be supplied with a cutover date arbitrarily far in the past.
       $calendar = IntlGregorianCalendar::createInstance();
-      $calendar->setGregorianChange(PHP_INT_MIN);
+      // NOTE: IntlGregorianCalendar::createInstance DOES NOT return an IntlGregorianCalendar instance when
+      // using a non-Gregorian locale (e.g. fa_IR)! In that case, setGregorianChange will not exist.
+      if (method_exists($calendar, 'setGregorianChange')) $calendar->setGregorianChange(PHP_INT_MIN);
 
       return (new IntlDateFormatter($locale, $date_type, $time_type, $tz, $calendar, $pattern))->format($timestamp);
     };

--- a/src/php-8.1-strftime.php
+++ b/src/php-8.1-strftime.php
@@ -97,7 +97,9 @@
       $calendar = IntlGregorianCalendar::createInstance();
       // NOTE: IntlGregorianCalendar::createInstance DOES NOT return an IntlGregorianCalendar instance when
       // using a non-Gregorian locale (e.g. fa_IR)! In that case, setGregorianChange will not exist.
-      if (method_exists($calendar, 'setGregorianChange')) $calendar->setGregorianChange(PHP_INT_MIN);
+      if ($calendar instanceof IntlGregorianCalendar) {
+        $calendar->setGregorianChange(PHP_INT_MIN);
+      }
 
       return (new IntlDateFormatter($locale, $date_type, $time_type, $tz, $calendar, $pattern))->format($timestamp);
     };


### PR DESCRIPTION
Fix strftime behaviour with non-Gregorian locales. See https://github.com/alphp/strftime/issues/15 for details.