### PR TITLE
Add locale-param to PHPDoc-block

### DIFF
--- a/src/php-8.1-strftime.php
+++ b/src/php-8.1-strftime.php
@@ -25,6 +25,7 @@
    *
    * @param  string $format Date format
    * @param  integer|string|DateTime $timestamp Timestamp
+   * @param  string|null $locale locale
    * @return string
    * @author BohwaZ <https://bohwaz.net/>
    */


### PR DESCRIPTION
Documentation for third parameter `$locale` was missing:
```php
function strftime (string $format, $timestamp = null, ?string $locale = null) : string {
```
